### PR TITLE
feat: allow passing executor name to job

### DIFF
--- a/src/jobs/render-config.yml
+++ b/src/jobs/render-config.yml
@@ -45,9 +45,7 @@ parameters:
       that already has gomplate installed, you can set this to false.
     type: boolean
   executor:
-    default:
-      name: default
-      tag: stable 
+    default: default
     type: executor
     description: The executor to run the job
   resource_class:

--- a/src/jobs/render-config.yml
+++ b/src/jobs/render-config.yml
@@ -1,8 +1,6 @@
 description: Render the provided template and run it as a dynamic config continuation pipeline
 
-executor:
-  name: << parameters.executor-name >>
-  tag: << parameters.tag >>
+executor: << parameters.executor >>
 
 parameters:
   template-file:
@@ -46,18 +44,12 @@ parameters:
       Whether to install gomplate or not. If you are using a custom executor
       that already has gomplate installed, you can set this to false.
     type: boolean
-  executor-name:
-    default: default
-    type: string
-    description: |
-      Pick a different executor name
-  tag:
-    default: "stable"
-    description: >
-      Sets the tag for the executor docker image.
-      Pick a specific circleci/base image variant:
-      https://hub.docker.com/r/cimg/base/tags
-    type: string
+  executor:
+    default:
+      name: default
+      tag: stable 
+    type: executor
+    description: The executor to run the job
   resource_class:
     default: small
     description: Resource class to use

--- a/src/jobs/render-config.yml
+++ b/src/jobs/render-config.yml
@@ -48,7 +48,7 @@ parameters:
     type: boolean
   executor-name:
     default: default
-    key: string
+    type: string
     description: |
       Pick a different executor name
   tag:

--- a/src/jobs/render-config.yml
+++ b/src/jobs/render-config.yml
@@ -48,6 +48,7 @@ parameters:
     type: boolean
   executor-name:
     default: default
+    key: string
     description: |
       Pick a different executor name
   tag:

--- a/src/jobs/render-config.yml
+++ b/src/jobs/render-config.yml
@@ -1,7 +1,7 @@
 description: Render the provided template and run it as a dynamic config continuation pipeline
 
 executor:
-  name: default
+  name: << parameters.executor-name >>
   tag: << parameters.tag >>
 
 parameters:
@@ -46,9 +46,14 @@ parameters:
       Whether to install gomplate or not. If you are using a custom executor
       that already has gomplate installed, you can set this to false.
     type: boolean
+  executor-name:
+    default: default
+    description: |
+      Pick a different executor name
   tag:
     default: "stable"
     description: >
+      Sets the tag for the executor docker image.
       Pick a specific circleci/base image variant:
       https://hub.docker.com/r/cimg/base/tags
     type: string


### PR DESCRIPTION
Adds an `executor-name` parameter to allow the user to override the default executor for the job